### PR TITLE
added vifm+ueberzug run script, vifm must be launched with vimrun

### DIFF
--- a/.local/bin/tools/vifmrun
+++ b/.local/bin/tools/vifmrun
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+export FIFO_UEBERZUG="/tmp/vifm-ueberzug-${PPID}"
+
+function cleanup {
+    rm "$FIFO_UEBERZUG" 2>/dev/null
+    pkill -P $$ 2>/dev/null
+}
+
+rm "$FIFO_UEBERZUG" 2>/dev/null
+mkfifo "$FIFO_UEBERZUG"
+trap cleanup EXIT
+tail --follow "$FIFO_UEBERZUG" | ueberzug layer --silent --parser bash &
+
+vifm
+cleanup


### PR DESCRIPTION
got it to work ... saw a video on distrotube about it, it was actually a reply to your video where you talk about ueberzug .. the problem was that you were missing the run script to launch vifm with ueber ... so I changed the F alias to vifmrun and now you have image previews :)

I have also found 2-3 better more configured vifmimg files ill test them out then maybe open another pull request :)